### PR TITLE
Display Last Month filter for all charts by default

### DIFF
--- a/src/components/ChartPreview.vue
+++ b/src/components/ChartPreview.vue
@@ -72,7 +72,7 @@ const { getDataMethodName } = toRefs(props)
 const chartData = ref()
 const isLoading = ref(false)
 const isLoadingError = ref(false)
-const sortingValue = ref(sortingDaysForChart.lastDay.value)
+const sortingValue = ref(sortingDaysForChart.lastMonth.value)
 
 onMounted(async (): Promise<void> => {
   await getChartData()

--- a/src/components/ChartPreview.vue
+++ b/src/components/ChartPreview.vue
@@ -73,6 +73,7 @@ const chartData = ref()
 const isLoading = ref(false)
 const isLoadingError = ref(false)
 const sortingValue = ref(sortingDaysForChart.lastMonth.value)
+const sortingValueYear = ref(sortingDaysForChart.lastYear.value)
 
 onMounted(async (): Promise<void> => {
   await getChartData()
@@ -82,7 +83,8 @@ const getChartData = async () => {
   const endDate = new Date()
   const startDate = new Date()
 
-  startDate.setDate(startDate.getDate() - Number(sortingValue.value))
+  const sorting_value = getDataMethodName.value == "getRequestsVolumePerDays" ? sortingValueYear.value : sortingValue.value
+  startDate.setDate(startDate.getDate() - Number(sorting_value))
   isLoading.value = true
 
   try {

--- a/src/helpers/helpers.ts
+++ b/src/helpers/helpers.ts
@@ -148,7 +148,7 @@ export const sortingDaysForChart = {
     text: 'Last 14 days',
     value: '14',
   },
-  lastMoth: {
+  lastMonth: {
     text: 'Last month',
     value: '31',
   },

--- a/src/views/ChartView.vue
+++ b/src/views/ChartView.vue
@@ -115,12 +115,17 @@ const { getDataMethodName } = toRefs(props)
 const chartData = ref()
 const isLoading = ref(false)
 const sortingValue = ref(sortingDaysForChart.lastMonth.value)
+const sortingValueYear = ref(sortingDaysForChart.lastYear.value)
 const isLoadingError = ref(false)
 
 const getChartData = async () => {
   const endDate = new Date()
   const startDate = new Date()
-  startDate.setDate(startDate.getDate() - Number(sortingValue.value))
+  const sorting_value =
+    getDataMethodName.value == 'getRequestsVolumePerDays'
+      ? sortingValueYear.value
+      : sortingValue.value
+  startDate.setDate(startDate.getDate() - Number(sorting_value))
   isLoading.value = true
   try {
     const { data } = await callers[getDataMethodName.value](startDate, endDate)

--- a/src/views/ChartView.vue
+++ b/src/views/ChartView.vue
@@ -114,7 +114,7 @@ const props = withDefaults(
 const { getDataMethodName } = toRefs(props)
 const chartData = ref()
 const isLoading = ref(false)
-const sortingValue = ref(sortingDaysForChart.lastWeek.value)
+const sortingValue = ref(sortingDaysForChart.lastMonth.value)
 const isLoadingError = ref(false)
 
 const getChartData = async () => {


### PR DESCRIPTION
- Display Last Month filter for all charts by default on both preview on chart pages