### PR TITLE
fix: use `getOfflineSignerAuto` for ledger support

### DIFF
--- a/src/api/wallet.ts
+++ b/src/api/wallet.ts
@@ -1,5 +1,8 @@
 import { AccountData, OfflineSigner } from '@cosmjs/launchpad'
-import { DirectSecp256k1HdWallet } from '@cosmjs/proto-signing'
+import {
+  DirectSecp256k1HdWallet,
+  OfflineDirectSigner,
+} from '@cosmjs/proto-signing'
 import { API_CONFIG } from './api-config'
 import { Window as KeplrWindow } from '@keplr-wallet/types'
 
@@ -14,11 +17,15 @@ export enum WalletTypes {
 }
 
 export class OdinWallet {
-  _wallet: DirectSecp256k1HdWallet | OfflineSigner | null = null
+  _wallet:
+      | DirectSecp256k1HdWallet
+      | OfflineSigner
+      | OfflineDirectSigner
+      | null = null
   _walletAccounts: readonly AccountData[] | null = null
   _walletType: WalletTypes | null = null
 
-  get signer(): DirectSecp256k1HdWallet | OfflineSigner {
+  get signer(): DirectSecp256k1HdWallet | OfflineSigner | OfflineDirectSigner {
     if (!this._wallet) {
       throw new ReferenceError('OdinWallet not initialized!')
     }
@@ -47,20 +54,20 @@ export class OdinWallet {
     if (walletData.type === WalletTypes.ODIN_WALLET) {
       DirectSecp256k1HdWallet.fromMnemonic
       this._wallet = await DirectSecp256k1HdWallet.fromMnemonic(
-        walletData.key,
-        {
-          hdPaths: [API_CONFIG.hdDeviation],
-          prefix: 'odin',
-        },
+          walletData.key,
+          {
+            hdPaths: [API_CONFIG.hdDeviation],
+            prefix: 'odin',
+          },
       )
     } else if (walletData.type === WalletTypes.KEPLR_WALLET) {
       const offlineSigner =
-        window.getOfflineSigner != null
-          ? window.getOfflineSigner(walletData.key)
-          : null
+          window.getOfflineSignerAuto != null
+              ? await window.getOfflineSignerAuto(walletData.key)
+              : null
       if (offlineSigner === null)
         throw new ReferenceError(
-          'Something went wrong. Error with offline signer.',
+            'Something went wrong. Error with offline signer.',
         )
       this._wallet = offlineSigner
     }

--- a/src/api/wallet.ts
+++ b/src/api/wallet.ts
@@ -18,10 +18,10 @@ export enum WalletTypes {
 
 export class OdinWallet {
   _wallet:
-      | DirectSecp256k1HdWallet
-      | OfflineSigner
-      | OfflineDirectSigner
-      | null = null
+    | DirectSecp256k1HdWallet
+    | OfflineSigner
+    | OfflineDirectSigner
+    | null = null
   _walletAccounts: readonly AccountData[] | null = null
   _walletType: WalletTypes | null = null
 
@@ -54,20 +54,20 @@ export class OdinWallet {
     if (walletData.type === WalletTypes.ODIN_WALLET) {
       DirectSecp256k1HdWallet.fromMnemonic
       this._wallet = await DirectSecp256k1HdWallet.fromMnemonic(
-          walletData.key,
-          {
-            hdPaths: [API_CONFIG.hdDeviation],
-            prefix: 'odin',
-          },
+        walletData.key,
+        {
+          hdPaths: [API_CONFIG.hdDeviation],
+          prefix: 'odin',
+        },
       )
     } else if (walletData.type === WalletTypes.KEPLR_WALLET) {
       const offlineSigner =
-          window.getOfflineSignerAuto != null
-              ? await window.getOfflineSignerAuto(walletData.key)
-              : null
+        window.getOfflineSignerAuto != null
+          ? await window.getOfflineSignerAuto(walletData.key)
+          : null
       if (offlineSigner === null)
         throw new ReferenceError(
-            'Something went wrong. Error with offline signer.',
+          'Something went wrong. Error with offline signer.',
         )
       this._wallet = offlineSigner
     }


### PR DESCRIPTION
The issue was because of ledger wallet supports only AminoSigner. There was used the `OfflineDirectSigner` method, which uses Protobuf.
Because of the incompatibility of decoders, the error was raised. 

I have tested only with `/cosmos.staking.v1beta1.MsgDelegate` I'm not sure how it will be working with other types of transactions.

Video with successful ledger transaction: 
https://drive.google.com/file/d/1NiFo6_CqLo2nlz2--kqYz3nyKHH1zCi0/view
 
 
Note: 

https://tutorials.cosmos.network/tutorials/7-cosmjs/2-first-steps.html
```
The recommended way to encode messages is by using OfflineDirectSigner, which uses Protobuf. 
However, hardware wallets such as Ledger do not support this and still require the legacy Amino encoder.
If your app requires Amino support, you have to use the OfflineAminoSigner
```
About `getOfflineSignerAuto`
https://docs.keplr.app/api/cosmjs.html#types-of-offline-signers