### PR TITLE
fix: connect wallet error in first time 

### DIFF
--- a/src/views/AuthView.vue
+++ b/src/views/AuthView.vue
@@ -113,6 +113,8 @@ const flattenForm = form.flatten()
 const copyWarning = ref(false)
 
 const submit = async () => {
+  // prevent double submit
+  if (isLoading.value === true) return
   lockLoading()
   try {
     if (props.loginType === LOGIN_TYPE.KEPLR118) {


### PR DESCRIPTION
##  What does this PR do? 

This PR fixes the error when a user connects the wallet to the page.
This error happens only when ODIN doesn't exist in the user's wallet and initiates `addExperimentalChain`

UI error: 
<img width="958" alt="Screenshot 2023-12-20 at 17 00 38" src="https://github.com/ODIN-PROTOCOL/odin-web/assets/26277721/48c46fb8-0f15-4a7a-b35f-1293325f6d8f">
## What causes the issue and what is the solution
For some reason `submit` calls 2 times. This fix prevents double submission by `useBooleanSemaphore`